### PR TITLE
Run illegalTransitiveDependencyCheck in process-classes phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
               <goals>
                 <goal>enforce</goal>
               </goals>
-              <phase>initialize</phase>
+              <phase>process-classes</phase>
               <configuration>
                 <fail>${enforceStandards}</fail>
                 <rules>


### PR DESCRIPTION
It needs to run in the process-classes otherwise there are no classes for it to analyse
