### PR TITLE
Update plugins and add abiity to use another Apache license format.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+
+Introduction
+============
+
+This contains a common parent for all projects to use.
+
+Releasing Projects
+==================
+
+The release profile enables the maven-gpg-plugin, maven-source-plugin and the license-maven-plugin. Note that the license-maven-plugin ( See [here](http://code.mycila.com/license-maven-plugin) ) has a standard format for licenses. An alternative format for the Apache 2 license is available by specifiying
+
+    <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+           <header>APACHE-2-SIMPLIFIED-COPYRIGHT.txt</header>
+        </configuration>
+    </plugin>
+
+in the project configuration. The allows `Copyright (C) ${project.inceptionYear} ${owner}` instead of `Copyright (C) ${project.inceptionYear} ${owner} (${email})`.
+
+Releasing the releng-tools project
+==================================
+
+As the license-plugin must have the license module as a dependency, a project variable is used. This means that when releasing this variable **must** be specified e.g.
+
+    mvn -DdryRun=true release:prepare -DglobalVersion=<next release version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,24 +60,24 @@
     <projectEmail>jcasey@redhat.com</projectEmail>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.plugin.assembly>2.5.5</version.plugin.assembly>
-    <version.plugin.clean>2.6.1</version.plugin.clean>
-    <version.plugin.compiler>3.1</version.plugin.compiler>
+    <version.plugin.assembly>2.6</version.plugin.assembly>
+    <version.plugin.clean>3.0.0</version.plugin.clean>
+    <version.plugin.compiler>3.7.0</version.plugin.compiler>
     <version.plugin.deploy>2.8.2</version.plugin.deploy>
-    <version.plugin.enforcer>1.4</version.plugin.enforcer>
-    <version.plugin.failsafe>2.18.1</version.plugin.failsafe>
-    <version.plugin.gpg>1.1</version.plugin.gpg>
+    <version.plugin.enforcer>3.0.0-M1</version.plugin.enforcer>
+    <version.plugin.failsafe>2.20.1</version.plugin.failsafe>
+    <version.plugin.gpg>1.6</version.plugin.gpg>
     <version.plugin.install>2.5.2</version.plugin.install>
-    <version.plugin.jar>2.4</version.plugin.jar>
+    <version.plugin.jar>3.0.2</version.plugin.jar>
     <version.plugin.javadoc>2.8.1</version.plugin.javadoc>
-    <version.plugin.plexus-component-metadata>1.5.5</version.plugin.plexus-component-metadata>
-    <version.plugin.plugin>3.2</version.plugin.plugin>
-    <version.plugin.release>2.5</version.plugin.release>
-    <version.plugin.resources>2.6</version.plugin.resources>
-    <version.plugin.site>3.3</version.plugin.site>
-    <version.plugin.source>2.1.2</version.plugin.source>
-    <version.plugin.surefire>2.18.1</version.plugin.surefire>
-    <version.plugin.pmd>3.6</version.plugin.pmd>
+    <version.plugin.plexus-component-metadata>1.7</version.plugin.plexus-component-metadata>
+    <version.plugin.plugin>3.5</version.plugin.plugin>
+    <version.plugin.release>2.5.3</version.plugin.release>
+    <version.plugin.resources>3.0.2</version.plugin.resources>
+    <version.plugin.site>3.6</version.plugin.site>
+    <version.plugin.source>3.0.1</version.plugin.source>
+    <version.plugin.surefire>2.20.1</version.plugin.surefire>
+    <version.plugin.pmd>3.8</version.plugin.pmd>
 
     <illegaltransitivereportonly>false</illegaltransitivereportonly>
     <enforceManagedDeps>true</enforceManagedDeps>
@@ -384,7 +384,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>buildnumber-maven-plugin</artifactId>
-          <version>1.3</version>
+          <version>1.4</version>
           <executions>
             <execution>
               <phase>validate</phase>
@@ -420,7 +420,7 @@
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>2.10</version>
+          <version>2.11</version>
           <configuration>
             <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
             <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -440,6 +440,13 @@
               <service>SCRIPT_STYLE</service>
             </mapping>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>com.redhat.rcm</groupId>
+              <artifactId>redhat-releng-license-templates</artifactId>
+              <version>1</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->


### PR DESCRIPTION
@jdcasey This pull request does two things:

1. Updates all plugin versions to their latest EXCEPT the assembly plugin. I have left that on the 2.x series. Updating that to the 3.x series changes my build time from e.g. 8 seconds to 2min15sec or from 39 seconds to 1min38secs.

2. I have added a submodule with a custom Apache 2 license format in it. Its identical to the current one barring the removal of the email address. This means projects inheriting from this can choose to use it by simply adding
```      
       <plugin>
          <groupId>com.mycila</groupId>
          <artifactId>license-maven-plugin</artifactId>
          <configuration>
            <header>APACHE-2-SIMPLIFIED-COPYRIGHT.txt</header>
          </configuration>
        </plugin>
```
in their pom. Note that there is **no** change to projects using the current format.

